### PR TITLE
Create missing parent dirs when writing to a file.

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,7 @@
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::Path;
+use std::fs;
 
 use error::Result;
 
@@ -21,7 +23,12 @@ fn read(path: &str) -> Result<String> {
     Ok(content)
 }
 
-fn write(data: &str, path: &str) -> Result<usize> {
+fn write(data: &str, path_str: &str) -> Result<usize> {
+    let path = Path::new(path_str);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?
+    }
+
     let mut file = File::create(path)?;
 
     Ok(file.write(data.as_bytes())?)


### PR DESCRIPTION
The BYOND `text2file` proc will automagically create all parent directories of the target file if they don't exist.  In order for the rust `file_write` to be a drop-in replacement for `text2file`, it should do the same.